### PR TITLE
Mcp/shell

### DIFF
--- a/examples/shell.ts
+++ b/examples/shell.ts
@@ -9,7 +9,7 @@ import url from 'url'
 import readline from 'readline'
 
 // Utility for human approval
-async function getHumanApproval(command: string, args: string[], purpose: string): Promise<boolean> {
+async function getHumanApproval(command: string, args: string[]): Promise<boolean> {
   const rl = readline.createInterface({
     input: process.stdin,
     output: process.stdout
@@ -18,7 +18,6 @@ async function getHumanApproval(command: string, args: string[], purpose: string
   return new Promise((resolve) => {
     rl.question(
       `Command: ${command} ${args.join(' ')}\n` +  
-      `Purpose: ${purpose}\n` +
       `Approve? [y/N]: `,
       (answer) => {
         rl.close()

--- a/examples/shell.ts
+++ b/examples/shell.ts
@@ -1,0 +1,100 @@
+import * as shellMcp from "@unroute/mcp-shell"
+import dotenv from "dotenv"
+import EventSource from "eventsource"
+import { OpenAI } from "openai"
+import type { ChatCompletionMessageParam } from "openai/resources/chat/index"
+import { Connection } from "../src/index"
+import { OpenAIHandler } from "../src/openai"
+import url from 'url'
+import readline from 'readline'
+
+// Utility for human approval
+async function getHumanApproval(command: string, args: string[], purpose: string): Promise<boolean> {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout
+  })
+
+  return new Promise((resolve) => {
+    rl.question(
+      `Command: ${command} ${args.join(' ')}\n` +  
+      `Purpose: ${purpose}\n` +
+      `Approve? [y/N]: `,
+      (answer) => {
+        rl.close()
+        resolve(answer.toLowerCase() === 'y')
+      }
+    )
+  })
+}
+
+// Patch event source
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+global.EventSource = EventSource as any
+
+async function main() {
+  dotenv.config()
+
+  // Initialize the OpenAI client
+  const openai = new OpenAI()
+
+  // Connect to MCPs
+  const connection = await Connection.connect({
+    shell: {
+      server: shellMcp.createServer({
+        allowedCommands: ['ls', 'pwd', 'date', 'echo'],
+        approvalHandler: getHumanApproval
+      }),
+    },
+  })
+
+  // Example conversation with tool usage
+  let isDone = false
+  const messages: ChatCompletionMessageParam[] = [
+    {
+      role: "user",
+      content: "What's the date?",
+    },
+  ]
+
+  const handler = new OpenAIHandler(connection)
+
+  while (!isDone) {
+    const response = await openai.chat.completions.create({
+      model: "gpt-4-turbo-preview",
+      messages,
+      tools: await handler.listTools(),
+    })
+
+    // Handle tool calls - will prompt for approval during execution
+    const toolMessages = await handler.call(response)
+    messages.push(response.choices[0].message)
+    messages.push(...toolMessages)
+    isDone = toolMessages.length === 0
+    console.log("Processing messages:", 
+      messages.map(m => ({
+        role: m.role,
+        content: m.content,
+        tools: ('tool_calls' in m) ? m.tool_calls?.length : 0
+      }))
+    )
+  }
+
+  // Print the final conversation
+  console.log("\nFinal conversation:")
+  messages.forEach((msg) => {
+    console.log(`\n${msg.role.toUpperCase()}:`)
+    console.log(msg.content)
+    if (msg.role === "assistant" && msg.tool_calls) {
+      console.log("Tool calls:", JSON.stringify(msg.tool_calls, null, 2))
+    }
+  })
+}
+
+// Run the example
+if (import.meta.url === url.pathToFileURL(process.argv[1]).href) {
+  main().catch((err) => {
+    console.error("Error:", err)
+    process.exit(1)
+  })
+}

--- a/mcps/shell/package.json
+++ b/mcps/shell/package.json
@@ -1,0 +1,27 @@
+{
+	"name": "@unroute/mcp-shell",
+	"version": "0.0.2",
+	"author": "Henry Mao & MCP Team",
+	"type": "module",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"files": [
+	  "dist"
+	],
+	"scripts": {
+	  "build": "tsc",
+	  "watch": "tsc --watch"
+	},
+	"dependencies": {
+	  "@modelcontextprotocol/sdk": "^0.7.0",
+	  "zod": "^3.22.0",
+	  "zod-to-json-schema": "^3.22.0"
+	},
+	"devDependencies": {
+	  "@types/node": "^20.11.0",
+	  "typescript": "^5.3.3"
+	},
+	"peerDependencies": {
+	  "@modelcontextprotocol/sdk": "^0.7.0"
+	}
+  }

--- a/mcps/shell/src/index.ts
+++ b/mcps/shell/src/index.ts
@@ -1,0 +1,151 @@
+import { Server } from "@modelcontextprotocol/sdk/server/index.js"
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+  ToolSchema,
+} from "@modelcontextprotocol/sdk/types.js"
+import { z } from "zod"
+import { zodToJsonSchema } from "zod-to-json-schema"
+import { spawn } from "node:child_process"
+
+// Schema definitions
+export const ExecuteCommandArgsSchema = z.object({
+  command: z.string().describe("The command to execute"),
+  args: z.array(z.string()).describe("Command arguments"),
+  purpose: z.string().describe("Explanation of what this command will do and why it's needed"),
+})
+
+const ToolInputSchema = ToolSchema.shape.inputSchema
+type ToolInput = z.infer<typeof ToolInputSchema>
+
+// Allowlist of safe commands
+const ALLOWED_COMMANDS = new Set(["ls", "pwd", "echo", "cat", "wc", "date"])
+
+// Execute command safely
+async function executeCommand(command: string, args: string[]): Promise<{stdout: string, stderr: string}> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(command, args)
+    let stdout = ""
+    let stderr = ""
+
+    proc.stdout.on("data", (data) => {
+      stdout += data.toString()
+    })
+
+    proc.stderr.on("data", (data) => {
+      stderr += data.toString()
+    })
+
+    proc.on("close", (code) => {
+      if (code !== 0) {
+        reject(new Error(`Command failed with code ${code}\n${stderr}`))
+      } else {
+        resolve({ stdout, stderr })
+      }
+    })
+
+    setTimeout(() => {
+      proc.kill()
+      reject(new Error("Command timed out after 5 seconds"))
+    }, 5000)
+  })
+}
+
+export interface ShellServerOptions {
+  allowedCommands?: string[]
+  timeout?: number
+  approvalHandler?: (command: string, args: string[], purpose: string) => Promise<boolean>
+}
+
+export function createServer(options: ShellServerOptions = {}) {
+  const server = new Server(
+    {
+      name: "shell-command-server",
+      version: "0.1.0",
+    },
+    {
+      capabilities: {
+        tools: {},
+      },
+    }
+  )
+
+  // Override defaults with options
+  const customAllowedCommands = options.allowedCommands
+  if (customAllowedCommands) {
+    customAllowedCommands.forEach(cmd => ALLOWED_COMMANDS.add(cmd))
+  }
+
+  const approvalHandler = options.approvalHandler || (() => Promise.resolve(true))
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => {
+    return {
+      tools: [
+        {
+          name: "execute_command",
+          description: 
+            `Execute a shell command safely. Only allowed commands: ${[...ALLOWED_COMMANDS].join(", ")}. ` +
+            "Provide a clear purpose explaining what the command will do. " +
+            "Command will require human approval before execution.",
+          inputSchema: zodToJsonSchema(ExecuteCommandArgsSchema) as ToolInput,
+        },
+      ],
+    }
+  })
+
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    try {
+      const { name, arguments: args } = request.params
+
+      if (name !== "execute_command") {
+        throw new Error(`Unknown tool: ${name}`)
+      }
+
+      const parsed = ExecuteCommandArgsSchema.safeParse(args)
+      if (!parsed.success) {
+        throw new Error(`Invalid arguments: ${parsed.error}`)
+      }
+
+      const { command, args: cmdArgs, purpose } = parsed.data
+
+      // Validate command
+      if (!ALLOWED_COMMANDS.has(command)) {
+        throw new Error(`Command not allowed: ${command}`)
+      }
+
+      // Get human approval with purpose
+      const approved = await approvalHandler(command, cmdArgs, purpose)
+      if (!approved) {
+        return {
+          content: [{ 
+            type: "text", 
+            text: "Command was not approved by user."
+          }],
+        }
+      }
+
+      // Execute command
+      const result = await executeCommand(command, cmdArgs)
+      
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Executed: ${command} ${cmdArgs.join(" ")}\nOutput:\n${result.stdout}${
+              result.stderr ? `\nErrors:\n${result.stderr}` : ""
+            }`,
+          },
+        ],
+      }
+
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error)
+      return {
+        content: [{ type: "text", text: `Error: ${errorMessage}` }],
+        isError: true,
+      }
+    }
+  })
+
+  return server
+}

--- a/mcps/shell/src/index.ts
+++ b/mcps/shell/src/index.ts
@@ -12,7 +12,6 @@ import { spawn } from "node:child_process"
 export const ExecuteCommandArgsSchema = z.object({
   command: z.string().describe("The command to execute"),
   args: z.array(z.string()).describe("Command arguments"),
-  purpose: z.string().describe("A very concise explanation of what this command will do"),
 })
 
 const ToolInputSchema = ToolSchema.shape.inputSchema
@@ -54,7 +53,7 @@ async function executeCommand(command: string, args: string[]): Promise<{stdout:
 export interface ShellServerOptions {
   allowedCommands?: string[]
   timeout?: number
-  approvalHandler?: (command: string, args: string[], purpose: string) => Promise<boolean>
+  approvalHandler?: (command: string, args: string[]) => Promise<boolean>
 }
 
 export function createServer(options: ShellServerOptions = {}) {
@@ -106,15 +105,15 @@ export function createServer(options: ShellServerOptions = {}) {
         throw new Error(`Invalid arguments: ${parsed.error}`)
       }
 
-      const { command, args: cmdArgs, purpose } = parsed.data
+      const { command, args: cmdArgs } = parsed.data
 
       // Validate command
       if (!ALLOWED_COMMANDS.has(command)) {
         throw new Error(`Command not allowed: ${command}`)
       }
 
-      // Get human approval with purpose
-      const approved = await approvalHandler(command, cmdArgs, purpose)
+      // Get human approval without purpose
+      const approved = await approvalHandler(command, cmdArgs)
       if (!approved) {
         return {
           content: [{ 

--- a/mcps/shell/src/index.ts
+++ b/mcps/shell/src/index.ts
@@ -12,7 +12,7 @@ import { spawn } from "node:child_process"
 export const ExecuteCommandArgsSchema = z.object({
   command: z.string().describe("The command to execute"),
   args: z.array(z.string()).describe("Command arguments"),
-  purpose: z.string().describe("Explanation of what this command will do and why it's needed"),
+  purpose: z.string().describe("A very concise explanation of what this command will do"),
 })
 
 const ToolInputSchema = ToolSchema.shape.inputSchema

--- a/mcps/shell/tsconfig.json
+++ b/mcps/shell/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"outDir": "./dist",
+		"baseUrl": "."
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
 				"@unroute/mcp-e2b": "*",
 				"@unroute/mcp-exa": "*",
 				"@unroute/mcp-fs": "*",
+				"@unroute/mcp-shell": "*",
 				"dotenv": "^16.4.7",
 				"eventsource": "^2.0.2",
 				"tsx": "^4.19.2",
@@ -87,6 +88,32 @@
 				"@types/lodash": "^4.17.13",
 				"@types/node": "^20.11.0",
 				"typescript": "^5.3.3"
+			}
+		},
+		"mcps/shell": {
+			"name": "@unroute/mcp-shell",
+			"version": "0.0.2",
+			"dependencies": {
+				"@modelcontextprotocol/sdk": "^0.7.0",
+				"zod": "^3.22.0",
+				"zod-to-json-schema": "^3.22.0"
+			},
+			"devDependencies": {
+				"@types/node": "^20.11.0",
+				"typescript": "^5.3.3"
+			},
+			"peerDependencies": {
+				"@modelcontextprotocol/sdk": "^0.7.0"
+			}
+		},
+		"mcps/shell/node_modules/@modelcontextprotocol/sdk": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-0.7.0.tgz",
+			"integrity": "sha512-YlnQf8//eDHClUM607vb/6+GHmCdMnIfOkN2pcpexN4go9sYHm2JfNnqc5ILS7M8enUlwe9dQO9886l3NO3rUw==",
+			"dependencies": {
+				"content-type": "^1.0.5",
+				"raw-body": "^3.0.0",
+				"zod": "^3.23.8"
 			}
 		},
 		"node_modules/@anthropic-ai/sdk": {
@@ -598,6 +625,10 @@
 		},
 		"node_modules/@unroute/mcp-fs": {
 			"resolved": "mcps/fs",
+			"link": true
+		},
+		"node_modules/@unroute/mcp-shell": {
+			"resolved": "mcps/shell",
 			"link": true
 		},
 		"node_modules/@unroute/sdk": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 		"@unroute/mcp-e2b": "*",
 		"@unroute/mcp-exa": "*",
 		"@unroute/mcp-fs": "*",
+		"@unroute/mcp-shell": "*",
 		"dotenv": "^16.4.7",
 		"eventsource": "^2.0.2",
 		"tsx": "^4.19.2",


### PR DESCRIPTION
Added a shell execution MCP server that allows running allowed shell commands with human approval.

## Details
- Added `mcp-shell` package
- Added example in `examples/shell.ts`
- Uses command execution through Node's `spawn`
- Timeout of 5 seconds for commands
- For now, allowlist includes safe read commands: ls, pwd, echo, cat, wc, date

## Example
```typescript
  // Connect to MCP
  const connection = await Connection.connect({
    shell: {
      server: shellMcp.createServer({
        allowedCommands: ['ls', 'pwd', 'date', 'echo'],
        approvalHandler: getHumanApproval
      }),
    },
  })